### PR TITLE
Firefox 4 Back Button bug with prototype and zepto Adapter

### DIFF
--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -1632,10 +1632,10 @@
 					else if ( typeof event.event !== 'undefined' && typeof event.event.state !== 'undefined' ) {
 						event.state = event.event.state||false;
 					}
+					// Ensure
+					event.state = (event.state||false);
 				}
 
-				// Ensure
-				event.state = (event.state||false);
 
 				// Fetch State
 				if ( event.state ) {


### PR DESCRIPTION
When using the prototypeJS or zepto Adapter, the back button in Firefox 4 doesn't trigger "statechange". It works with jquery and mootools. 

The problem is the line "event.state = (event.state||false);" at which FF stops. I moved the line into the "if ( typeof event.state === 'undefined')" condition and it works.
