### PR TITLE
String escaping - URLs with %252F

### DIFF
--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -655,7 +655,7 @@
 			var newState = {};
 			newState.normalized = true;
 			newState.title = oldState.title||'';
-			newState.url = History.getFullUrl(History.unescapeString(oldState.url||document.location.href));
+			newState.url = History.getFullUrl(oldState.url||document.location.href);
 			newState.hash = History.getShortUrl(newState.url);
 			newState.data = History.cloneObject(oldState.data);
 


### PR DESCRIPTION
Hi,

I'm having trouble with a string escaping issue. I'm on a page and I want to pushState to:

http://blah.com/This%252FThat

Because of the string unescaping, the URL pushed is:

http://blah.com/This/That

and the mismatch between the two causes the browser to get upset and just load the page fresh. The attached fixes the issue in HTML5 Firefoxes / Chromes, but it probably upsets the fallback hashing (which doesn't seem to work in this case either with or without the patch).

Would be great if you could take a look.

Thanks,

Arthur
