### PR TITLE
Force no suid

### DIFF
--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -97,6 +97,12 @@
 		History.options.doubleCheckInterval = History.options.doubleCheckInterval || 500;
 
 		/**
+		 * History.options.disableSuid
+		 * Force History not to append suid
+		 */
+		History.options.disableSuid = History.options.disableSuid || false;
+
+		/**
 		 * History.options.storeInterval
 		 * How long should we wait between store calls
 		 */
@@ -672,7 +678,7 @@
 			var dataNotEmpty = !History.isEmptyObject(newState.data);
 
 			// Apply
-			if ( newState.title || dataNotEmpty ) {
+			if ( (newState.title || dataNotEmpty) && History.options.disableSuid != true ) {
 				// Add ID to Hash
 				newState.hash = History.getShortUrl(newState.url).replace(/\??\&_suid.*/,'');
 				if ( !/\?/.test(newState.hash) ) {


### PR DESCRIPTION
Sometimes, you might want to be certain there's no _suid appended to your "pretty" urls. This just adds an option to permit that.
