### PR TITLE
fix to QUOTA_EXCEEDED_ERR exception

### DIFF
--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -1885,6 +1885,7 @@
 				History.normalizeStore();
 
 				// Store
+				sessionStorage.removeItem('History.store');
 				sessionStorage.setItem('History.store',JSON.stringify(currentStore));
 			};
 


### PR DESCRIPTION
Fixed QUOTA_EXCEEDED_ERR exception by adding removeItem before setItem.

Solution found here...
http://stackoverflow.com/questions/2603682/is-anyone-else-receiving-a-quota-exceeded-err-on-their-ipad-when-accessing-local/2616820#2616820
