### PR TITLE
Modify history.js to match current W3C popState event semantics (uncompresses only)

### DIFF
--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -1652,7 +1652,6 @@
 				else {
 					// Initial State
 					newState = History.extractState(document.location.href);
-					wasExpected = !! newState;
 				}
 
 				// The State did not exist in our store

--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -1608,7 +1608,7 @@
 			 */
 			History.onPopState = function(event,extra){
 				// Prepare
-				var stateId = false, newState = false, currentHash, currentState;
+				var stateId = false, newState = false, currentHash, currentState, wasExpected;
 
 				// Reset the double check
 				History.doubleCheckComplete();
@@ -1647,10 +1647,12 @@
 				else if ( History.expectedStateId ) {
 					// Vanilla: A new state was pushed, and popstate was called manually
 					newState = History.getStateById(History.expectedStateId);
+					wasExpected = !! newState;
 				}
 				else {
 					// Initial State
 					newState = History.extractState(document.location.href);
+					wasExpected = !! newState;
 				}
 
 				// The State did not exist in our store
@@ -1677,8 +1679,10 @@
 				// Force update of the title
 				History.setTitle(newState);
 
-				// Fire Our Event
-				History.Adapter.trigger(window,'statechange');
+				// Fire Our Event .. match popstate semantics 
+				if ( ! wasExpected )
+					History.Adapter.trigger(window,'statechange');
+
 				History.busy(false);
 
 				// Return true


### PR DESCRIPTION
"
4. If the third argument is present, set the document's current address to the absolute URL that was found earlier in this algorithm.

Since this is neither a navigation of the browsing context nor a history traversal, it does not cause a hashchange event to be fired.
"
I believe that " this is not a navigation" also applies to popState (as this this cause applies to push push and replace state)

The changes to history.js bring statechange (event) in line with the spec.
