### PR TITLE
fix: MooTools version < 1.3 doesn't support Object.append

### DIFF
--- a/scripts/uncompressed/history.adapter.mootools.js
+++ b/scripts/uncompressed/history.adapter.mootools.js
@@ -13,7 +13,8 @@
 	var
 		History = window.History = window.History||{},
 		MooTools = window.MooTools,
-		Element = window.Element;
+		Element = window.Element,
+		append  = Object.hasOwnProperty('append') ? Object.append : Hash.extend;
 
 	// Check Existence
 	if ( typeof History.Adapter !== 'undefined' ) {
@@ -21,7 +22,8 @@
 	}
 
 	// Make MooTools aware of History.js Events
-	Object.append(Element.NativeEvents,{
+	
+	append(Element.NativeEvents,{
 		'popstate':2,
 		'hashchange':2
 	});


### PR DESCRIPTION
MooTools pre 1.3 uses Hash instad of Object, so we simply need to determine if Object supports append.
