### PR TITLE
Prevent Safari 5.0.x poll from interfering with pushState until hash change propagates

### DIFF
--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -1477,6 +1477,10 @@
 		};
 
 		History.blockSafariPollUntilPropagation = function(newState){
+			// clear existing interval in preparation for the new one
+			if (History.waitForPropagationInterval) {
+				clearInterval(History.waitForPropagationInterval);
+			}
 			History.waitForPropagation = true;
 			History.waitForPropagationInterval = setInterval(function() {
 				var urlState = History.extractState(document.location.href);

--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -895,7 +895,9 @@
 		 */
 		History.getIdByUrl = function(url){
 			// Fetch
-			var id = History.urlToId[url] || History.store.urlToId[url] || undefined;
+			var unescaped = History.unescapeString(url);
+			var id = History.urlToId[url] || History.store.urlToId[url] ||
+                                 History.urlToId[unescaped] || History.store.urlToId[unescaped] || undefined;
 
 			// Return
 			return id;
@@ -948,7 +950,9 @@
 		 */
 		History.storeState = function(newState){
 			// Store the State
-			History.urlToId[newState.url] = newState.id;
+			History.urlToId[newState.cleanUrl] = newState.id;
+			History.idToState[newState.id] = newState;
+			History.stateToId[History.getStateString(newState)] = newState.id;
 
 			// Push the State
 			History.storedStates.push(History.cloneObject(newState));
@@ -1749,14 +1753,14 @@
 					History.busy(false);
 				}
 				else {
+					// Store the newState
+					History.storeState(newState);
+					History.expectedStateId = newState.id;
+
 					if (History.bugs.safariPoll) {
 						//History.debug('Blocking safariPoll until url state propagation');
 						History.blockSafariPollUntilPropagation(newState);
 					}
-
-					// Store the newState
-					History.storeState(newState);
-					History.expectedStateId = newState.id;
 
 					// Push the newState
 					history.pushState(newState.id,newState.title,newState.url);


### PR DESCRIPTION
If a pushState has just occurred and the Safari poller checks to see
if the hash has changed before the hashchange propagates, then it
sees the new state as being different from the actual state, thus
triggering a pushState. This patch sets a flag (waitForPropagation)
which is cleared by an interval after the hashchange finally
propagates.

The question.. what happens if a second pushState occurs before
the hashchange propagates?
