### PR TITLE
use window.decodeURI before window.unescape in History.unescapeString()

### DIFF
--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -1056,7 +1056,7 @@
 
 			// Unescape hash
 			while ( true ) {
-				tmp = window.unescape(result);
+				tmp = window.unescape(window.decodeURI(result));
 				if ( tmp === result ) {
 					break;
 				}


### PR DESCRIPTION
because only use unescape will lead to jumbled url if the url contains Chinese characters.
it is also recommended to use decodeURI instead of unescape: http://www.w3schools.com/jsref/jsref_unescape.asp
