### PR TITLE
Safari throws exception in Private Browsing mode due to setItem use.

### DIFF
--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -1884,8 +1884,17 @@
 				History.store = currentStore;
 				History.normalizeStore();
 
-				// Store
-				sessionStorage.setItem('History.store',JSON.stringify(currentStore));
+				// In Safari, going into Private Browsing mode causes the
+				// Session Storage object to still exist but if you try and use
+				// or set any property/function of it it throws the exception
+				// "QUOTA_EXCEEDED_ERR: DOM Exception 22: An attempt was made to
+				// add something to storage that exceeded the quota." infinitely
+				// every second.
+				try {
+					// Store
+					sessionStorage.setItem('History.store',JSON.stringify(currentStore));
+				}
+				catch (e) {}
 			};
 
 			// For Internet Explorer


### PR DESCRIPTION
In Safari, Private Browsing mode causes Session/Local Storage objects to still exist, but any attempt to use them throws an exception. To resolve, obviously I just wrapped the single setItem call in a try/catch.

```
QUOTA_EXCEEDED_ERR: DOM Exception 22: An attempt was made to add something to storage that exceeded the quota."
```
