### PR TITLE
Add option to force HTML4 Mode, and option to delay History.init()

### DIFF
--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -129,6 +129,12 @@
 		 */
 		 History.options.html4Mode = History.options.html4Mode || false;
 
+		/**
+		 * History.options.delayInit
+		 * Want to override default options and call init manually.
+		 */
+		 History.options.delayInit = History.options.delayInit || false;
+
 
 		// ====================================================================
 		// Interval record
@@ -1954,7 +1960,9 @@
 
 	}; // History.initCore
 
-	// Try and Initialise History
-	History.init();
+	if (!History.options || !History.options.delayInit) {
+		// Try and Initialise History
+		History.init();
+	}
 
 })(window);


### PR DESCRIPTION
Forcing HTML4 mode is very nice, especially in the case of wanting to test/debug something without having to open IE.

The delayInit option is also useful if you want to set History.options values at any time other than before loading in History.js.
