### PR TITLE
Fixed bug in html4 pushState function which left History in a busy state

### DIFF
--- a/scripts/uncompressed/history.html4.js
+++ b/scripts/uncompressed/history.html4.js
@@ -528,6 +528,7 @@
 				if ( newStateHash !== html4Hash && newStateHash !== History.getShortUrl(document.location.href) ) {
 					//History.debug('History.pushState: update hash', newStateHash, html4Hash);
 					History.setHash(newStateHash,false);
+					History.busy(false);
 					return false;
 				}
 


### PR DESCRIPTION
Basically if it ended up in the "History.pushState: update hash" if statement, it would leave History believing it was busy, someone forgot a History.busy(false);
