### PR TITLE
unescapeString broke unicode URLs

### DIFF
--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -1056,7 +1056,7 @@
 
 			// Unescape hash
 			while ( true ) {
-				tmp = window.unescape(result);
+				tmp = window.unescape(encodeURIComponent(result));
 				if ( tmp === result ) {
 					break;
 				}


### PR DESCRIPTION
createStateObject object passes the URL string to unescapeString. 
If the URL is http://myhost/リオれ then it becomes http://myhost/ãªãªã

fixed with this tiny change.
