### PR TITLE
Fixed typo in error thrown

### DIFF
--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -1700,7 +1700,7 @@
 
 				// Check the State
 				if ( History.getHashByUrl(url) && History.emulated.pushState ) {
-					throw new Error('History.js does not support states with fragement-identifiers (hashes/anchors).');
+					throw new Error('History.js does not support states with fragment-identifiers (hashes/anchors).');
 				}
 
 				// Handle Queueing


### PR DESCRIPTION
Changed `fragement` => `fragment`
