### PR TITLE
Fix for issue #273

### DIFF
--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -122,6 +122,12 @@
 		 * What is the title of the initial state
 		 */
 		History.options.initialTitle = History.options.initialTitle || document.title;
+		
+		/**
+         * History.options.transformHash
+         * If true will transform the HTML4 hash to HTML5 equivalence. Set to false if you want the hash to be just a plain string, no meaning whatsoever.
+         */
+        History.options.transformHash = History.options.transformHash || true;
 
 
 		// ====================================================================
@@ -1618,7 +1624,7 @@
 				if ( currentHash ) {
 					// Expand Hash
 					currentState = History.extractState(currentHash||document.location.href,true);
-					if ( currentState ) {
+					if ( History.options.transformHash && currentState ) {
 						// We were able to parse it, it must be a State!
 						// Let's forward to replaceState
 						//History.debug('History.onPopState: state anchor', currentHash, currentState);


### PR DESCRIPTION
Tumblr and Facebook started adding #somevalue.01 to their shared URLS. jquery.history is rewriting these urls.
