### PR TITLE
Correct fix for https://github.com/browserstate/history.js/pull/251

### DIFF
--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -1056,7 +1056,7 @@
 
 			// Unescape hash
 			while ( true ) {
-				tmp = window.unescape(result);
+				tmp = decodeURIComponent(result);
 				if ( tmp === result ) {
 					break;
 				}
@@ -1171,7 +1171,7 @@
 			var result = History.normalizeHash(hash);
 
 			// Escape hash
-			result = window.escape(result);
+			result = encodeURIComponent(result);
 
 			// IE6 Escape Bug
 			if ( !History.bugs.hashEscape ) {


### PR DESCRIPTION
unescapeString breaks unicode URLs

https://github.com/amitxlnc/history.js/compare/i18n

window.unescape/escape can not handle unicode chars, so you can use encodeURIComponent and decodeURIComponent
