### PR TITLE
Update proper semver versioning.

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,4 +1,4 @@
 {
   "name": "history.js",
-  "version": "1.8"
+  "version": "1.8.0"
 }


### PR DESCRIPTION
Bower requires you use [valid semver versioning]https://github.com/bower/bower/issues/144#issuecomment-10490902), however "1.8" does not suffice for this. You'll need 1.8.0. In the latest release of Bower, you get [all sorts of annoying issues](http://d.pr/i/Npyn) which mean history.js cannot be installed :(
