### PR TITLE
Fix Issue #292, wrong argument passed to History.getHash()

### DIFF
--- a/scripts/uncompressed/history.html4.js
+++ b/scripts/uncompressed/history.html4.js
@@ -319,7 +319,7 @@
 						// Fetch
 						var
 							documentHash = History.getHash(),
-							iframeHash = History.getHash(iframe.contentWindow.document.location);
+							iframeHash = History.getHash(iframe.contentWindow.document);
 
 						// The Document Hash has changed (application caused)
 						if ( documentHash !== lastDocumentHash ) {


### PR DESCRIPTION
Fix is for IE6 and IE7.

I'm having issues with dependencies, so I've been unable to run the build script for the compressed/bundled files.
