### PR TITLE
properly support the empty URI (a relative URI)

### DIFF
--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -744,7 +744,7 @@
 			newState = {};
 			newState.normalized = true;
 			newState.title = oldState.title||'';
-			newState.url = History.getFullUrl(oldState.url?oldState.url:(History.getLocationHref()));
+			newState.url = History.getFullUrl(oldState.url != null ? oldState.url : History.getLocationHref());
 			newState.hash = History.getShortUrl(newState.url);
 			newState.data = History.cloneObject(oldState.data);
 


### PR DESCRIPTION
Before this commit, `History.normalizeState` treated the empty string URI (`''`) as if no URI had been specified, normalizing it to the current page location (`History.getLocationHref()`). This occurred because the empty string is a "falsy" value in JavaScript.

With this commit, `History.normalizeState` instead resolves the empty URI as it does other relative URIs (using `History.getFullUrl`), while still resorting to `History.getLocationHref()` if no URI is specified (i.e. `oldState.url` is `null` or `undefined`).

I ran the tests in Chrome, and this commit causes no change in outcome. It's easy to see that this would be the case, since none of the current tests use the empty URI. It's also easy to see (by inspection of `History.getFullUrl`) that this change has the desired effect and no undesired side effects. I'd be happy to see a test added for the empty URI... I'm just not sure where the best place to add it would be. The tests appear to be a carefully constructed sequence.
