### PR TITLE
It looks for . in the domain, but it can be present in a param. Fix issue 316.

### DIFF
--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -927,7 +927,7 @@
 		 */
 		History.isTraditionalAnchor = function(url_or_hash){
 			// Check
-			var isTraditional = !(/[\/\?\.]/.test(url_or_hash));
+			var isTraditional = !(/[\/\?]/.test(url_or_hash));
 
 			// Return
 			return isTraditional;


### PR DESCRIPTION
You can still determine if a url is traditional or not without looking for a period.
