### PR TITLE
trying to access window.sessionStorage can throw SecurityError

### DIFF
--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -16,7 +16,7 @@
 		console = window.console||undefined, // Prevent a JSLint complain
 		document = window.document, // Make sure we are using the correct document
 		navigator = window.navigator, // Make sure we are using the correct navigator
-		sessionStorage = window.sessionStorage||false, // sessionStorage
+		sessionStorage = false, // sessionStorage
 		setTimeout = window.setTimeout,
 		clearTimeout = window.clearTimeout,
 		setInterval = window.setInterval,
@@ -27,6 +27,7 @@
 		history = window.history; // Old History Object
 
 	try {
+		sessionStorage = window.sessionStorage // can throw SecurityError
 		sessionStorage.setItem('TEST', '1');
 		sessionStorage.removeItem('TEST');
 	} catch(e) {


### PR DESCRIPTION
In chrome if the `Block sites from setting any data` is turned on trying to access window.sessionStorage throws a SecurityError exception.
