### PR TITLE
attempted fix for issue #339 - no more including host in hash on IE 8 and 9

### DIFF
--- a/scripts/bundled-uncompressed/html4+html5/jquery.history.js
+++ b/scripts/bundled-uncompressed/html4+html5/jquery.history.js
@@ -1789,7 +1789,11 @@ if (typeof JSON !== 'object') {
 				// We are in a if statement as when pushState is not emulated
 				// The actual url these short urls are relative to can change
 				// So within the same session, we the url may end up somewhere different
-				shortUrl = shortUrl.replace(baseUrl,'');
+
+                // also make sure to remove the trailing slash before removing the baseUrl
+                // from shortUrl, or it will not match the host
+                var baseUrlWithoutTrailingSlash = baseUrl.replace(/\/$/gi, '');
+                shortUrl = shortUrl.replace(baseUrlWithoutTrailingSlash,'');
 			}
 
 			// Trim rootUrl


### PR DESCRIPTION
In Internet Explorer IE8 and IE9 there seems to be a problem that includes the host in the hash.

```
http://www.example.com/?page=foobar -> http://www.example.com/#http://www.exmaple.com?page=foobar&_suid=123456789
but    
http://www.example.com/directory/?page=foobar -> http://www.example.com/directory/#?page=foobar&_suid=123456789
```

I noticed that in History.getShortUrl the baseUrl reports "http://www.example.com/" with a trailing slash. Consequently, shortUrl.replace, does not match anything because of the superfluous "/" at the end of baseUrl. Removing the trailing slash fixes the problem, as shortUrl gets returned correctly.

I only applied this to the uncompressed html4+html5 bundle for jquery as I have not used the other library integrations.
