### PR TITLE
Fix outdated copyright year (update to 2014)

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011, Benjamin Arthur Lupton
+Copyright (c) 2011-2014, Benjamin Arthur Lupton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
The copyright year was out of date. Copyright notices must reflect the current year. This commit updates the listed year to 2014.

see: http://www.copyright.gov/circs/circ03.pdf for more info
