### PR TITLE
remove period from traditional anchor test

### DIFF
--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -929,8 +929,6 @@
 		History.isTraditionalAnchor = function(url_or_hash){
 			// Check
 			var isTraditional = !(/[\/\?]/.test(url_or_hash));
-			// Previous test (/[\/\?\.]/) for tranditional anchor didn't allowed to use Google Analytics campaign tags properly
-			// for example: http://www.test.com/page-1#utm_source=myweb.com shrink to http://www.test.com/utm_source=myweb.com
 
 			// Return
 			return isTraditional;

--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -928,7 +928,9 @@
 		 */
 		History.isTraditionalAnchor = function(url_or_hash){
 			// Check
-			var isTraditional = !(/[\/\?\.]/.test(url_or_hash));
+			var isTraditional = !(/[\/\?]/.test(url_or_hash));
+			// Previous test (/[\/\?\.]/) for tranditional anchor didn't allowed to use Google Analytics campaign tags properly
+			// for example: http://www.test.com/page-1#utm_source=myweb.com shrink to http://www.test.com/utm_source=myweb.com
 
 			// Return
 			return isTraditional;


### PR DESCRIPTION
Previous test (/[\/\?\.]/) for traditional anchor didn't allowed to use Google Analytics campaign tags properly, for example: http://www.test.com/page-1#utm_source=myweb.com shrink to http://www.test.com/utm_source=myweb.com.