### PR TITLE
Avoid double-encoding URI

### DIFF
--- a/scripts/uncompressed/history.html4.js
+++ b/scripts/uncompressed/history.html4.js
@@ -488,7 +488,7 @@
 
 				// Push the new HTML5 State
 				//History.debug('History.onHashChange: success hashchange');
-				History.pushState(currentState.data,currentState.title,encodeURI(currentState.url),false);
+				History.pushState(currentState.data,currentState.title,currentState.url,false);
 
 				// End onHashChange closure
 				return true;


### PR DESCRIPTION
`pushState` already calls `encodeURI`. It's not necessary to call it in `onHashChange`.

If `currentState.url` is already encoded, e.g. `%3A`, then it will be double encoded by `encodeURI` (once in `onHashChange` and once in `pushState`), and `.replace(/%25/g, "%")` will only be run once in `pushState`, yielding a URL of `%253A`.
