### PR TITLE
Fix issue where re-loading history.js adapter breaks scripts when minifi...

### DIFF
--- a/scripts/bundled-uncompressed/html5/jquery.history.js
+++ b/scripts/bundled-uncompressed/html5/jquery.history.js
@@ -16,7 +16,8 @@
 
 	// Check Existence
 	if ( typeof History.Adapter !== 'undefined' ) {
-		throw new Error('History.js Adapter has already been loaded...');
+		console.log('History.js Adapter has already been loaded...');
+		return;
 	}
 
 	// Add the Adapter

--- a/scripts/uncompressed/history.adapter.jquery.js
+++ b/scripts/uncompressed/history.adapter.jquery.js
@@ -16,7 +16,8 @@
 
 	// Check Existence
 	if ( typeof History.Adapter !== 'undefined' ) {
-		throw new Error('History.js Adapter has already been loaded...');
+		console.log('History.js Adapter has already been loaded...');
+		return;
 	}
 
 	// Add the Adapter

--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -40,7 +40,8 @@
 
 	// Check Existence
 	if ( typeof History.init !== 'undefined' ) {
-		throw new Error('History.js Core has already been loaded...');
+		console.log('History.js Core has already been loaded...');
+		return;
 	}
 
 	// Initialise History


### PR DESCRIPTION
History.js adapter throws an error saying it has already been loaded. However, on a server that minifies multiple javascript files and compresses them into one, this results in an error that breaks the entire script which is poor practice.

A console.log and a return statement accomplish the same functionality while preserving functionality and not breaking existing scripts on a site.
