### PR TITLE
add 'main' and 'ignore' to bower config

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,6 @@
 {
   "name": "history.js",
-  "version": "1.8.0"
+  "version": "1.8.0",
+  "main": "scripts/uncompressed/history.js",
+  "ignore" : ["demo", "tests.src", "tests", "vendor", ".*", "buildr*", "component.json", "package.json"]
 }


### PR DESCRIPTION
The [bower-requirejs](https://github.com/yeoman/bower-requirejs) package uses the `"main"` field in bower.json to determine the main js file of a given package.  This PR adds "main", so history.js can easily included with RequireJS, through bower.  It also adds "ignore" for removing files that aren't needed at "runtime", to slim down the size on disk.

Let me know if there are any questions or if the "ignore" list should be tweaked at all.  Thanks for history.js!