### PR TITLE
Update jquery.history.js

### DIFF
--- a/scripts/bundled-uncompressed/html4+html5/jquery.history.js
+++ b/scripts/bundled-uncompressed/html4+html5/jquery.history.js
@@ -2044,6 +2044,13 @@ if (typeof JSON !== 'object') {
 		 */
 		History.createStateObject = function(data,title,url){
 			// Hashify
+			
+		// Cleanup for IE in file:// mode – doesn't interfere with other browsers
+		// Without this you get a loop with multiple copies of the URL in the URL
+		if (/^file\:\/\/\/?/i.test(url)) {
+		url = url.substr(url.lastIndexOf("\/")+1);
+		}
+	
 			var State = {
 				'data': data,
 				'title': title,


### PR DESCRIPTION
I produce a set of documentation templates that need to work just as well without a web server and I'm using history.js for this in html4 mode when there's no server. I had to make this change to the History.createStateObject method for IE, otherwise it gets into a loop appending copies of the URL onto itself. I have only modified the jQuery version because that's the one I'm using. I can imagine that the problem also exists in the other versions, however.