### PR TITLE
Library should just return instead of throwing error if already loaded

### DIFF
--- a/scripts/uncompressed/history.adapter.dojo.js
+++ b/scripts/uncompressed/history.adapter.dojo.js
@@ -18,7 +18,7 @@
 
 	// Check Existence
 	if ( typeof History.Adapter !== 'undefined' ) {
-		throw new Error('History.js Adapter has already been loaded...');
+		return; //History.js Adapter has already been loaded.
 	}
 
 	// Add the Adapter

--- a/scripts/uncompressed/history.adapter.extjs.js
+++ b/scripts/uncompressed/history.adapter.extjs.js
@@ -21,7 +21,7 @@
     
     // Check Existence
     if ( typeof History.Adapter !== 'undefined' ) {
-        throw new Error('History.js Adapter has already been loaded...');
+        return; //History.js Adapter has already been loaded.
     }
 
     // Add the Adapter

--- a/scripts/uncompressed/history.adapter.jquery.js
+++ b/scripts/uncompressed/history.adapter.jquery.js
@@ -16,7 +16,7 @@
 
 	// Check Existence
 	if ( typeof History.Adapter !== 'undefined' ) {
-		throw new Error('History.js Adapter has already been loaded...');
+		return; //History.js Adapter has already been loaded.
 	}
 
 	// Add the Adapter

--- a/scripts/uncompressed/history.adapter.mootools.js
+++ b/scripts/uncompressed/history.adapter.mootools.js
@@ -17,7 +17,7 @@
 
 	// Check Existence
 	if ( typeof History.Adapter !== 'undefined' ) {
-		throw new Error('History.js Adapter has already been loaded...');
+		return; //History.js Adapter has already been loaded.
 	}
 
 	// Make MooTools aware of History.js Events

--- a/scripts/uncompressed/history.adapter.native.js
+++ b/scripts/uncompressed/history.adapter.native.js
@@ -14,7 +14,7 @@
 
 	// Check Existence
 	if ( typeof History.Adapter !== 'undefined' ) {
-		throw new Error('History.js Adapter has already been loaded...');
+		return; //History.js Adapter has already been loaded.
 	}
 
 	// Add the Adapter

--- a/scripts/uncompressed/history.adapter.right.js
+++ b/scripts/uncompressed/history.adapter.right.js
@@ -18,7 +18,7 @@
 
 	// Check Existence
 	if ( typeof History.Adapter !== 'undefined' ) {
-		throw new Error('History.js Adapter has already been loaded...');
+		return; //History.js Adapter has already been loaded.
 	}
 
 	// Add the Adapter

--- a/scripts/uncompressed/history.adapter.zepto.js
+++ b/scripts/uncompressed/history.adapter.zepto.js
@@ -16,7 +16,7 @@
 
 	// Check Existence
 	if ( typeof History.Adapter !== 'undefined' ) {
-		throw new Error('History.js Adapter has already been loaded...');
+		return; //History.js Adapter has already been loaded.
 	}
 
 	// Add the Adapter

--- a/scripts/uncompressed/history.html4.js
+++ b/scripts/uncompressed/history.html4.js
@@ -22,7 +22,7 @@
 
 	// Check Existence
 	if ( typeof History.initHtml4 !== 'undefined' ) {
-		throw new Error('History.js HTML4 Support has already been loaded...');
+		return; //History.js HTML4 Support has already been loaded.
 	}
 
 

--- a/scripts/uncompressed/history.js
+++ b/scripts/uncompressed/history.js
@@ -40,7 +40,7 @@
 
 	// Check Existence
 	if ( typeof History.init !== 'undefined' ) {
-		throw new Error('History.js Core has already been loaded...');
+		return; //History.js Core has already been loaded.
 	}
 
 	// Initialise History


### PR DESCRIPTION
Updated history.js to act more like polyfill, if history.js is already present it just returns instead of throwing an error.
